### PR TITLE
Mistake in "first_coin_flip" formula for "Varying Amounts of Noise"

### DIFF
--- a/completed/Section 1 - Differential Privacy.ipynb
+++ b/completed/Section 1 - Differential Privacy.ipynb
@@ -701,7 +701,7 @@
     "    \n",
     "    true_result = torch.mean(db.float())\n",
     "\n",
-    "    first_coin_flip = (torch.rand(len(db)) < noise).float()\n",
+    "    first_coin_flip = (torch.rand(len(db)) > noise).float()\n",
     "    second_coin_flip = (torch.rand(len(db)) < 0.5).float()\n",
     "\n",
     "    augmented_database = db.float() * first_coin_flip + (1 - first_coin_flip) * second_coin_flip\n",


### PR DESCRIPTION
There is mistake in this line:    first_coin_flip = (torch.rand(len(db)) *<* noise).float()
it should be:  first_coin_flip = (torch.rand(len(db)) *>* noise).float()
E.g. if noise is 0.2 it means less noise, and when it is 0.8 it means more noise. right?
So, when it's 0.8 I have to get a true result wit probability 1-0.8 = 0.2.