### PR TITLE
fix accuracy for TFE plaintext training with TensorFlow 1.14

### DIFF
--- a/Section 4 - Encrypted Deep Learning.ipynb
+++ b/Section 4 - Encrypted Deep Learning.ipynb
@@ -1112,7 +1112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -1122,49 +1122,13 @@
       "x_train shape: (60000, 28, 28, 1)\n",
       "60000 train samples\n",
       "10000 test samples\n",
-      "WARNING:tensorflow:From /usr/local/miniconda3/envs/syft/lib/python3.6/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Colocations handled automatically by placer.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:From /usr/local/miniconda3/envs/syft/lib/python3.6/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Colocations handled automatically by placer.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Train on 60000 samples, validate on 10000 samples\n",
-      "WARNING:tensorflow:From /usr/local/miniconda3/envs/syft/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Use tf.cast instead.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:From /usr/local/miniconda3/envs/syft/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Use tf.cast instead.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Epoch 1/2\n",
-      "60000/60000 [==============================] - 26s 440us/sample - loss: 0.7004 - acc: 0.7795 - val_loss: 0.3245 - val_acc: 0.9011\n",
+      "60000/60000 [==============================] - 6s 106us/sample - loss: 0.7645 - acc: 0.7687 - val_loss: 0.4023 - val_acc: 0.8738\n",
       "Epoch 2/2\n",
-      "60000/60000 [==============================] - 22s 361us/sample - loss: 0.2265 - acc: 0.9311 - val_loss: 0.1698 - val_acc: 0.9487\n",
-      "Test loss: 0.1698406898036599\n",
-      "Test accuracy: 0.9487\n"
+      "60000/60000 [==============================] - 6s 96us/sample - loss: 0.3233 - acc: 0.9043 - val_loss: 0.2618 - val_acc: 0.9199\n",
+      "Test loss: 0.2617655298233032\n",
+      "Test accuracy: 0.9199\n"
      ]
     }
    ],
@@ -1218,7 +1182,7 @@
     "model.add(Dense(num_classes, activation='softmax'))\n",
     "\n",
     "model.compile(loss=keras.losses.categorical_crossentropy,\n",
-    "              optimizer=keras.optimizers.Adadelta(),\n",
+    "              optimizer=keras.optimizers.Adam(lr=0.001),\n",
     "              metrics=['accuracy'])\n",
     "\n",
     "model.fit(x_train, y_train,\n",
@@ -1672,7 +1636,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/completed/Section 4 - Encrypted Deep Learning.ipynb
+++ b/completed/Section 4 - Encrypted Deep Learning.ipynb
@@ -1292,7 +1292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -1302,49 +1302,13 @@
       "x_train shape: (60000, 28, 28, 1)\n",
       "60000 train samples\n",
       "10000 test samples\n",
-      "WARNING:tensorflow:From /Users/atrask/anaconda/lib/python3.6/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Colocations handled automatically by placer.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:From /Users/atrask/anaconda/lib/python3.6/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Colocations handled automatically by placer.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Train on 60000 samples, validate on 10000 samples\n",
-      "WARNING:tensorflow:From /Users/atrask/anaconda/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Use tf.cast instead.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:From /Users/atrask/anaconda/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Use tf.cast instead.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Epoch 1/2\n",
-      "60000/60000 [==============================] - 7s 119us/sample - loss: 0.6739 - acc: 0.7855 - val_loss: 0.2742 - val_acc: 0.9135\n",
+      "60000/60000 [==============================] - 6s 99us/sample - loss: 0.7854 - acc: 0.7628 - val_loss: 0.3587 - val_acc: 0.8940\n",
       "Epoch 2/2\n",
-      "60000/60000 [==============================] - 7s 122us/sample - loss: 0.2181 - acc: 0.9341 - val_loss: 0.1549 - val_acc: 0.9517\n",
-      "Test loss: 0.1548735132828355\n",
-      "Test accuracy: 0.9517\n"
+      "60000/60000 [==============================] - 6s 94us/sample - loss: 0.2984 - acc: 0.9122 - val_loss: 0.2233 - val_acc: 0.9297\n",
+      "Test loss: 0.22332475578784944\n",
+      "Test accuracy: 0.9297\n"
      ]
     }
    ],
@@ -1398,7 +1362,7 @@
     "model.add(Dense(num_classes, activation='softmax'))\n",
     "\n",
     "model.compile(loss=keras.losses.categorical_crossentropy,\n",
-    "              optimizer=keras.optimizers.Adadelta(),\n",
+    "              optimizer=keras.optimizers.Adam(lr=0.001),\n",
     "              metrics=['accuracy'])\n",
     "\n",
     "model.fit(x_train, y_train,\n",
@@ -1821,7 +1785,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello @iamtrask, 

As raised in this issue https://github.com/OpenMined/PySyft/issues/2346, in TensorFlow 1.14, they have changed the default learning rate for the Adadelta optimizer (1 to 0.001). Therefore if the users have TensorFlow 1.14 installed on their machine,  they will get a very low accuracy when training the MNIST model. 

To fix this problem, this PR replaces the optimizer by an Adam optimizer. It's the same fix made in [OpenMined repository](https://github.com/OpenMined/PySyft/blob/dev/examples/tutorials/Part%2013a%20-%20Secure%20Classification%20with%20Syft%20Keras%20and%20TFE%20-%20Public%20Training.ipynb).

Thank you, 